### PR TITLE
Ajusta layout por device e corrige reinício após game over

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -13,6 +13,7 @@ let isPaused = true;
 let lastTime = 0;
 let updateTime = 80;
 let message = 'Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡';
+let gameHasEnded = false;
 
 const limitScore = 20;
 const scoreBox = document.getElementById('scoreBox');
@@ -39,9 +40,14 @@ function randomFoodPosition() {
 }
 
 function startOnTap() {
-    if (isPaused) {
+    if (isPaused && !gameHasEnded) {
         isPaused = false;
     }
+}
+
+function endGame() {
+    gameHasEnded = true;
+    alert('A nave quebrou por danos estrutuais! ☠️ Seu placar: ' + score);
 }
 
 function applyDirection(nextDirection) {
@@ -172,12 +178,12 @@ function draw(currentTime) {
         const newHead = { x: snakeX, y: snakeY };
 
         if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
-            alert('☠️ Game Over! Seu score: ' + score);
+            endGame();
             return;
         }
 
         if (collision(newHead, snake)) {
-            alert('☠️ Game Over! Seu score: ' + score);
+            endGame();
             return;
         }
 
@@ -198,6 +204,7 @@ function collision(head, array) {
 }
 
 function restartGame() {
+    const shouldResumeLoop = gameHasEnded;
     snake = [{ x: box * 5, y: box * 5 }];
     direction = 'RIGHT';
     food = randomFoodPosition();
@@ -206,8 +213,13 @@ function restartGame() {
     isPaused = true;
     lastTime = 0;
     updateTime = 80;
+    gameHasEnded = false;
     message = 'Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡';
     messageDisplay.innerText = message;
+
+    if (shouldResumeLoop) {
+        requestAnimationFrame(draw);
+    }
 }
 
 requestAnimationFrame(draw);

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -13,6 +13,7 @@ let isPaused = true;
 let lastTime = 0;
 let updateTime = 80;
 let message = 'Tap the game to start and help Einstein capture the photons! 💡';
+let gameHasEnded = false;
 
 const limitScore = 20;
 const scoreBox = document.getElementById('scoreBox');
@@ -39,9 +40,14 @@ function randomFoodPosition() {
 }
 
 function startOnTap() {
-    if (isPaused) {
+    if (isPaused && !gameHasEnded) {
         isPaused = false;
     }
+}
+
+function endGame() {
+    gameHasEnded = true;
+    alert('The ship broke apart due to structural damage! ☠️ Your score: ' + score);
 }
 
 function applyDirection(nextDirection) {
@@ -172,12 +178,12 @@ function draw(currentTime) {
         const newHead = { x: snakeX, y: snakeY };
 
         if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
-            alert('☠️ Game Over! Your score: ' + score);
+            endGame();
             return;
         }
 
         if (collision(newHead, snake)) {
-            alert('☠️ Game Over! Your score: ' + score);
+            endGame();
             return;
         }
 
@@ -198,6 +204,7 @@ function collision(head, array) {
 }
 
 function restartGame() {
+    const shouldResumeLoop = gameHasEnded;
     snake = [{ x: box * 5, y: box * 5 }];
     direction = 'RIGHT';
     food = randomFoodPosition();
@@ -206,8 +213,13 @@ function restartGame() {
     isPaused = true;
     lastTime = 0;
     updateTime = 80;
+    gameHasEnded = false;
     message = 'Tap the game to start and help Einstein capture the photons! 💡';
     messageDisplay.innerText = message;
+
+    if (shouldResumeLoop) {
+        requestAnimationFrame(draw);
+    }
 }
 
 requestAnimationFrame(draw);

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,7 @@ body {
 }
 
 #restartBtn {
+    display: none;
     opacity: 0.95;
     padding: 6px 14px;
     font-size: 14px;
@@ -72,8 +73,8 @@ body {
 }
 
 .touch-controls {
+    display: none;
     width: min(92vw, 540px);
-    display: flex;
     justify-content: space-between;
     margin-top: 10px;
     padding: 6px 0;
@@ -186,9 +187,17 @@ h1 {
     background-color: #ca1600;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     body {
         padding: 8px 8px 20px;
+    }
+
+    #restartBtn {
+        display: inline-block;
+    }
+
+    .touch-controls {
+        display: flex;
     }
 
     #gameCanvas {


### PR DESCRIPTION
### Motivation
- Manter a experiência desktop sem controles por toque e sem botão de reiniciar visível enquanto exibir controles e botão de reinício apenas em dispositivos mobile/tablet. 
- Impedir que o jogo reinicie por toque após um `game over` e permitir que o botão `Reiniciar` retome o loop para jogar novamente. 
- Trocar a mensagem de `game over` para os textos solicitados em Português e Inglês.

### Description
- CSS: escondi `#restartBtn` e `.touch-controls` por padrão e passei a mostrá-los via `@media (max-width: 1024px)` alterando o breakpoint de `768px` para `1024px` (file `styles.css`).
- JS: adicionei a flag `gameHasEnded` e a função `endGame()` em `functions.js` e `functionsEN.js` para centralizar o término do jogo e exibir os novos alertas de `game over` (PT/EN). 
- JS: `startOnTap()` agora ignora taps quando `gameHasEnded` é `true`, e `restartGame()` reseta o estado e reinicia o loop (`requestAnimationFrame`) quando necessário para permitir jogar novamente (files `functions.js`, `functionsEN.js`).
- Mensagens atualizadas: PT `A nave quebrou por danos estrutuais! ☠️ Seu placar:` e EN `The ship broke apart due to structural damage! ☠️ Your score:` (em `endGame()` de `functions.js` e `functionsEN.js`).

### Testing
- Executei `node --check functions.js && node --check functionsEN.js` e ambos os arquivos passaram sem erros. 
- Rodei um servidor local com `python3 -m http.server 4173` e capturei uma screenshot via Playwright para validar o layout em viewport de tablet, gerando um artefato visual com sucesso. 
- Verifiquei que ao atingir condição de `game over` o `endGame()` mostra o alerta correto e que ao clicar em `Reiniciar` o jogo é reiniciado e o loop de atualização volta a executar conforme esperado.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34bf51b708326a202f48ed418b6e0)