### PR TITLE
Introduce game-over state handling and adjust responsive layout/styles

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -13,6 +13,7 @@ let isPaused = true;
 let lastTime = 0;
 let updateTime = 80;
 let message = 'Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡';
+let gameHasEnded = false;
 
 const limitScore = 20;
 const scoreBox = document.getElementById('scoreBox');
@@ -39,9 +40,14 @@ function randomFoodPosition() {
 }
 
 function startOnTap() {
-    if (isPaused) {
+    if (isPaused && !gameHasEnded) {
         isPaused = false;
     }
+}
+
+function endGame() {
+    gameHasEnded = true;
+    alert('A nave quebrou por danos estrutuais! ☠️ Seu placar: ' + score);
 }
 
 function applyDirection(nextDirection) {
@@ -172,12 +178,12 @@ function draw(currentTime) {
         const newHead = { x: snakeX, y: snakeY };
 
         if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
-            alert('☠️ Game Over! Seu score: ' + score);
+            endGame();
             return;
         }
 
         if (collision(newHead, snake)) {
-            alert('☠️ Game Over! Seu score: ' + score);
+            endGame();
             return;
         }
 
@@ -198,6 +204,7 @@ function collision(head, array) {
 }
 
 function restartGame() {
+    const shouldResumeLoop = gameHasEnded;
     snake = [{ x: box * 5, y: box * 5 }];
     direction = 'RIGHT';
     food = randomFoodPosition();
@@ -206,8 +213,13 @@ function restartGame() {
     isPaused = true;
     lastTime = 0;
     updateTime = 80;
+    gameHasEnded = false;
     message = 'Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡';
     messageDisplay.innerText = message;
+
+    if (shouldResumeLoop) {
+        requestAnimationFrame(draw);
+    }
 }
 
 requestAnimationFrame(draw);

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -13,6 +13,7 @@ let isPaused = true;
 let lastTime = 0;
 let updateTime = 80;
 let message = 'Tap the game to start and help Einstein capture the photons! 💡';
+let gameHasEnded = false;
 
 const limitScore = 20;
 const scoreBox = document.getElementById('scoreBox');
@@ -39,9 +40,14 @@ function randomFoodPosition() {
 }
 
 function startOnTap() {
-    if (isPaused) {
+    if (isPaused && !gameHasEnded) {
         isPaused = false;
     }
+}
+
+function endGame() {
+    gameHasEnded = true;
+    alert('The ship broke apart due to structural damage! ☠️ Your score: ' + score);
 }
 
 function applyDirection(nextDirection) {
@@ -172,12 +178,12 @@ function draw(currentTime) {
         const newHead = { x: snakeX, y: snakeY };
 
         if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
-            alert('☠️ Game Over! Your score: ' + score);
+            endGame();
             return;
         }
 
         if (collision(newHead, snake)) {
-            alert('☠️ Game Over! Your score: ' + score);
+            endGame();
             return;
         }
 
@@ -198,6 +204,7 @@ function collision(head, array) {
 }
 
 function restartGame() {
+    const shouldResumeLoop = gameHasEnded;
     snake = [{ x: box * 5, y: box * 5 }];
     direction = 'RIGHT';
     food = randomFoodPosition();
@@ -206,8 +213,13 @@ function restartGame() {
     isPaused = true;
     lastTime = 0;
     updateTime = 80;
+    gameHasEnded = false;
     message = 'Tap the game to start and help Einstein capture the photons! 💡';
     messageDisplay.innerText = message;
+
+    if (shouldResumeLoop) {
+        requestAnimationFrame(draw);
+    }
 }
 
 requestAnimationFrame(draw);

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,12 @@
+html {
+    height: 100%;
+    overflow: hidden;
+}
+
 body {
-    min-height: 100vh;
+    height: 100dvh;
     margin: 0;
-    padding: 10px 10px 22px;
+    padding: 8px 10px 20px;
     box-sizing: border-box;
     background-color: #000;
     color: #f0f0f0;
@@ -9,11 +14,16 @@ body {
     background-image: url("./images/starbackground.jpg");
     background-repeat: no-repeat;
     background-size: cover;
+    overflow: hidden;
 }
 
 .game-page {
     max-width: 1200px;
     margin: 0 auto;
+    width: 100%;
+    height: calc(100dvh - 20px);
+    display: flex;
+    flex-direction: column;
 }
 
 .title {
@@ -25,24 +35,27 @@ body {
     width: 100%;
     letter-spacing: 2px;
     gap: 8px;
-    margin: 8px 0 24px;
+    margin: 4px 0 10px;
 }
 
 .container {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
     align-items: center;
+    justify-content: center;
+    flex: 1;
 }
 
 #gameCanvas {
-    width: min(92vw, 540px);
-    max-height: 74vh;
+    width: auto;
+    height: min(64vh, 960px);
+    max-width: min(92vw, 540px);
     aspect-ratio: 9 / 16;
     border: 1px solid #f0f0f0;
     background-color: #111;
     opacity: 0.95;
-    border-radius: 10px;
+    border-radius: 5px;
     touch-action: manipulation;
 }
 
@@ -61,6 +74,7 @@ body {
 }
 
 #restartBtn {
+    display: inline-block;
     opacity: 0.95;
     padding: 6px 14px;
     font-size: 14px;
@@ -72,8 +86,8 @@ body {
 }
 
 .touch-controls {
+    display: none;
     width: min(92vw, 540px);
-    display: flex;
     justify-content: space-between;
     margin-top: 10px;
     padding: 6px 0;
@@ -123,10 +137,6 @@ body {
 footer {
     font-size: 12px;
     text-align: center;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
     margin: 0;
     padding: 0 0 2px;
 }
@@ -186,14 +196,19 @@ h1 {
     background-color: #ca1600;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     body {
-        padding: 8px 8px 20px;
+        padding: 8px 8px 16px;
+    }
+
+    .touch-controls {
+        display: flex;
     }
 
     #gameCanvas {
-        aspect-ratio: 9 / 16;
-        max-height: 70vh;
+        width: min(92vw, 540px);
+        height: auto;
+        max-height: 60vh;
     }
 
     .touch-controls {


### PR DESCRIPTION
### Motivation

- Centralize and correctly track the game-over state to avoid duplicated alerts and prevent the game from being restarted or resumed incorrectly after ending.
- Improve layout and touch control behavior for better fullscreen and mobile experience.

### Description

- Added a `gameHasEnded` flag and an `endGame()` helper in `functions.js` and `functionsEN.js`, replacing inline `alert` calls with a single game-over handler.
- Prevented starting the game via tap when `gameHasEnded` is true and updated `restartGame()` to reset `gameHasEnded` and conditionally resume the animation loop when appropriate.
- Updated `styles.css` to use `100dvh` for full-height layout, hide overflow, adjust paddings/margins, refine canvas sizing and border radius, and change the touch-control visibility breakpoint to `@media (max-width: 1024px)` with related spacing tweaks.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34bf51b708326a202f48ed418b6e0)