### PR TITLE
Add explicit game-over state, fix touch control mapping, and improve responsive layout

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -13,6 +13,7 @@ let isPaused = true;
 let lastTime = 0;
 let updateTime = 80;
 let message = 'Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡';
+let gameHasEnded = false;
 
 const limitScore = 20;
 const scoreBox = document.getElementById('scoreBox');
@@ -39,9 +40,14 @@ function randomFoodPosition() {
 }
 
 function startOnTap() {
-    if (isPaused) {
+    if (isPaused && !gameHasEnded) {
         isPaused = false;
     }
+}
+
+function endGame() {
+    gameHasEnded = true;
+    alert('A nave quebrou por danos estrutuais! ☠️ Seu placar: ' + score);
 }
 
 function applyDirection(nextDirection) {
@@ -172,12 +178,12 @@ function draw(currentTime) {
         const newHead = { x: snakeX, y: snakeY };
 
         if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
-            alert('☠️ Game Over! Seu score: ' + score);
+            endGame();
             return;
         }
 
         if (collision(newHead, snake)) {
-            alert('☠️ Game Over! Seu score: ' + score);
+            endGame();
             return;
         }
 
@@ -198,6 +204,7 @@ function collision(head, array) {
 }
 
 function restartGame() {
+    const shouldResumeLoop = gameHasEnded;
     snake = [{ x: box * 5, y: box * 5 }];
     direction = 'RIGHT';
     food = randomFoodPosition();
@@ -206,8 +213,13 @@ function restartGame() {
     isPaused = true;
     lastTime = 0;
     updateTime = 80;
+    gameHasEnded = false;
     message = 'Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡';
     messageDisplay.innerText = message;
+
+    if (shouldResumeLoop) {
+        requestAnimationFrame(draw);
+    }
 }
 
 requestAnimationFrame(draw);

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -13,6 +13,7 @@ let isPaused = true;
 let lastTime = 0;
 let updateTime = 80;
 let message = 'Tap the game to start and help Einstein capture the photons! 💡';
+let gameHasEnded = false;
 
 const limitScore = 20;
 const scoreBox = document.getElementById('scoreBox');
@@ -39,9 +40,14 @@ function randomFoodPosition() {
 }
 
 function startOnTap() {
-    if (isPaused) {
+    if (isPaused && !gameHasEnded) {
         isPaused = false;
     }
+}
+
+function endGame() {
+    gameHasEnded = true;
+    alert('The ship broke apart due to structural damage! ☠️ Your score: ' + score);
 }
 
 function applyDirection(nextDirection) {
@@ -172,12 +178,12 @@ function draw(currentTime) {
         const newHead = { x: snakeX, y: snakeY };
 
         if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
-            alert('☠️ Game Over! Your score: ' + score);
+            endGame();
             return;
         }
 
         if (collision(newHead, snake)) {
-            alert('☠️ Game Over! Your score: ' + score);
+            endGame();
             return;
         }
 
@@ -198,6 +204,7 @@ function collision(head, array) {
 }
 
 function restartGame() {
+    const shouldResumeLoop = gameHasEnded;
     snake = [{ x: box * 5, y: box * 5 }];
     direction = 'RIGHT';
     food = randomFoodPosition();
@@ -206,8 +213,13 @@ function restartGame() {
     isPaused = true;
     lastTime = 0;
     updateTime = 80;
+    gameHasEnded = false;
     message = 'Tap the game to start and help Einstein capture the photons! 💡';
     messageDisplay.innerText = message;
+
+    if (shouldResumeLoop) {
+        requestAnimationFrame(draw);
+    }
 }
 
 requestAnimationFrame(draw);

--- a/game.html
+++ b/game.html
@@ -30,10 +30,10 @@
             <div class="touch-controls" aria-label="Controles por toque">
                 <div class="control-group left-group">
                     <button class="control-btn" data-direction="LEFT" aria-label="Mover para a esquerda">←</button>
-                    <button class="control-btn" data-direction="UP" aria-label="Mover para cima">↑</button>
+                    <button class="control-btn" data-direction="DOWN" aria-label="Mover para baixo">↓</button>
                 </div>
                 <div class="control-group right-group">
-                    <button class="control-btn" data-direction="DOWN" aria-label="Mover para baixo">↓</button>
+                    <button class="control-btn" data-direction="UP" aria-label="Mover para cima">↑</button>
                     <button class="control-btn" data-direction="RIGHT" aria-label="Mover para a direita">→</button>
                 </div>
             </div>

--- a/gameEN.html
+++ b/gameEN.html
@@ -30,10 +30,10 @@
             <div class="touch-controls" aria-label="Touch controls">
                 <div class="control-group left-group">
                     <button class="control-btn" data-direction="LEFT" aria-label="Move left">←</button>
-                    <button class="control-btn" data-direction="UP" aria-label="Move up">↑</button>
+                    <button class="control-btn" data-direction="DOWN" aria-label="Move down">↓</button>
                 </div>
                 <div class="control-group right-group">
-                    <button class="control-btn" data-direction="DOWN" aria-label="Move down">↓</button>
+                    <button class="control-btn" data-direction="UP" aria-label="Move up">↑</button>
                     <button class="control-btn" data-direction="RIGHT" aria-label="Move right">→</button>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -74,6 +74,7 @@ body {
 }
 
 #restartBtn {
+    /* Merge resolution: keep restart visible on desktop and mobile. */
     display: inline-block;
     opacity: 0.95;
     padding: 6px 14px;

--- a/styles.css
+++ b/styles.css
@@ -1,7 +1,12 @@
+html {
+    height: 100%;
+    overflow: hidden;
+}
+
 body {
-    min-height: 100vh;
+    height: 100dvh;
     margin: 0;
-    padding: 10px 10px 22px;
+    padding: 8px 10px 20px;
     box-sizing: border-box;
     background-color: #000;
     color: #f0f0f0;
@@ -9,11 +14,16 @@ body {
     background-image: url("./images/starbackground.jpg");
     background-repeat: no-repeat;
     background-size: cover;
+    overflow: hidden;
 }
 
 .game-page {
     max-width: 1200px;
     margin: 0 auto;
+    width: 100%;
+    height: calc(100dvh - 20px);
+    display: flex;
+    flex-direction: column;
 }
 
 .title {
@@ -25,24 +35,27 @@ body {
     width: 100%;
     letter-spacing: 2px;
     gap: 8px;
-    margin: 8px 0 24px;
+    margin: 4px 0 10px;
 }
 
 .container {
     display: flex;
     flex-direction: column;
-    gap: 10px;
+    gap: 8px;
     align-items: center;
+    justify-content: center;
+    flex: 1;
 }
 
 #gameCanvas {
-    width: min(92vw, 540px);
-    max-height: 74vh;
+    width: auto;
+    height: min(64vh, 960px);
+    max-width: min(92vw, 1000px);
     aspect-ratio: 9 / 16;
     border: 1px solid #f0f0f0;
     background-color: #111;
     opacity: 0.95;
-    border-radius: 10px;
+    border-radius: 5px;
     touch-action: manipulation;
 }
 
@@ -61,6 +74,7 @@ body {
 }
 
 #restartBtn {
+    display: inline-block;
     opacity: 0.95;
     padding: 6px 14px;
     font-size: 14px;
@@ -72,8 +86,8 @@ body {
 }
 
 .touch-controls {
+    display: none;
     width: min(92vw, 540px);
-    display: flex;
     justify-content: space-between;
     margin-top: 10px;
     padding: 6px 0;
@@ -123,10 +137,6 @@ body {
 footer {
     font-size: 12px;
     text-align: center;
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
     margin: 0;
     padding: 0 0 2px;
 }
@@ -186,14 +196,19 @@ h1 {
     background-color: #ca1600;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
     body {
-        padding: 8px 8px 20px;
+        padding: 8px 8px 16px;
+    }
+
+    .touch-controls {
+        display: flex;
     }
 
     #gameCanvas {
-        aspect-ratio: 9 / 16;
-        max-height: 70vh;
+        width: min(92vw, 540px);
+        height: auto;
+        max-height: 60vh;
     }
 
     .touch-controls {


### PR DESCRIPTION
### Motivation

- Prevent the game loop from being reactivated after a game-over and centralize end-of-game behavior to avoid duplicated alerts and inconsistent resume behavior.
- Correct the touch control mapping so the on-screen up/down buttons match their intended directions.
- Improve layout and canvas sizing to provide a more consistent responsive experience across viewports and to hide touch controls on larger screens.

### Description

- Introduced a `gameHasEnded` flag and an `endGame()` function in `functions.js` and `functionsEN.js`, and replaced direct `alert` game-over calls with `endGame()` to centralize end-of-game handling.
- Updated `startOnTap()` to prevent unpausing when the game has ended and modified `restartGame()` to reset `gameHasEnded` and conditionally resume the `draw` loop with `requestAnimationFrame(draw)` when restarting after an ended game.
- Swapped the `data-direction` attributes for the up/down touch buttons in `game.html` and `gameEN.html` to correct the touch-control layout.
- Reworked `styles.css` to set full-height behavior using `100dvh`, adjust canvas sizing and aspect behavior, refine paddings/margins and border radius, hide touch controls by default and reveal them below `1024px`, and remove the fixed footer positioning.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a34bf51b708326a202f48ed418b6e0)