### PR TITLE
Ajusta dimensões do canvas para desktop/mobile e controles

### DIFF
--- a/game.html
+++ b/game.html
@@ -30,10 +30,10 @@
             <div class="touch-controls" aria-label="Controles por toque">
                 <div class="control-group left-group">
                     <button class="control-btn" data-direction="LEFT" aria-label="Mover para a esquerda">←</button>
-                    <button class="control-btn" data-direction="UP" aria-label="Mover para cima">↑</button>
+                    <button class="control-btn" data-direction="DOWN" aria-label="Mover para baixo">↓</button>
                 </div>
                 <div class="control-group right-group">
-                    <button class="control-btn" data-direction="DOWN" aria-label="Mover para baixo">↓</button>
+                    <button class="control-btn" data-direction="UP" aria-label="Mover para cima">↑</button>
                     <button class="control-btn" data-direction="RIGHT" aria-label="Mover para a direita">→</button>
                 </div>
             </div>

--- a/gameEN.html
+++ b/gameEN.html
@@ -30,10 +30,10 @@
             <div class="touch-controls" aria-label="Touch controls">
                 <div class="control-group left-group">
                     <button class="control-btn" data-direction="LEFT" aria-label="Move left">←</button>
-                    <button class="control-btn" data-direction="UP" aria-label="Move up">↑</button>
+                    <button class="control-btn" data-direction="DOWN" aria-label="Move down">↓</button>
                 </div>
                 <div class="control-group right-group">
-                    <button class="control-btn" data-direction="DOWN" aria-label="Move down">↓</button>
+                    <button class="control-btn" data-direction="UP" aria-label="Move up">↑</button>
                     <button class="control-btn" data-direction="RIGHT" aria-label="Move right">→</button>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,9 @@
+html,
+body {
+    height: 100%;
+    overflow: hidden;
+}
+
 body {
     min-height: 100vh;
     margin: 0;
@@ -14,6 +20,9 @@ body {
 .game-page {
     max-width: 1200px;
     margin: 0 auto;
+    height: calc(100vh - 24px);
+    display: flex;
+    flex-direction: column;
 }
 
 .title {
@@ -36,18 +45,18 @@ body {
 }
 
 #gameCanvas {
-    width: min(92vw, 540px);
-    max-height: 74vh;
+    width: min(88vw, 1000px);
+    max-height: 62vh;
     aspect-ratio: 9 / 16;
     border: 1px solid #f0f0f0;
     background-color: #111;
     opacity: 0.95;
-    border-radius: 10px;
+    border-radius: 5px;
     touch-action: manipulation;
 }
 
 .info {
-    width: min(92vw, 540px);
+    width: min(88vw, 1000px);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -61,7 +70,7 @@ body {
 }
 
 #restartBtn {
-    display: none;
+    display: inline-block;
     opacity: 0.95;
     padding: 6px 14px;
     font-size: 14px;
@@ -110,7 +119,7 @@ body {
 }
 
 #messageDisplay {
-    width: min(92vw, 540px);
+    width: min(88vw, 1000px);
     font-size: clamp(18px, 2.3vw, 24px);
     text-align: center;
     display: flex;
@@ -192,17 +201,19 @@ h1 {
         padding: 8px 8px 20px;
     }
 
-    #restartBtn {
-        display: inline-block;
-    }
-
     .touch-controls {
         display: flex;
     }
 
     #gameCanvas {
-        aspect-ratio: 9 / 16;
-        max-height: 70vh;
+        width: min(92vw, 540px);
+        max-height: 60vh;
+    }
+
+    .info,
+    .touch-controls,
+    #messageDisplay {
+        width: min(92vw, 540px);
     }
 
     .touch-controls {


### PR DESCRIPTION
### Motivation
- Evitar rolagem e fazer o jogo encaixar no viewport em todos os dispositivos, mantendo textos e quadrados do canvas legíveis. 
- Ter configurações distintas para desktop e mobile (largura máxima para desktop, limite de altura para mobile) e aplicar `border-radius: 5px`. 
- Mostrar o botão de reiniciar também na versão desktop e trocar as posições das setas cima/baixo nos controles touch. 

### Description
- Atualiza `styles.css` para aplicar `overflow: hidden` em `html, body`, definir layout da página com altura limitada ao viewport e ajustar o canvas para `width: min(88vw, 1000px)` e `max-height: 62vh` no desktop, além de `border-radius: 5px`. 
- Adiciona regras na media query `@media (max-width: 1024px)` para usar `width: min(92vw, 540px)` e `max-height: 60vh` no mobile e unificar a largura de `.info`, `.touch-controls` e `#messageDisplay` para dispositivos menores. 
- Torna o botão `#restartBtn` visível por padrão (`display: inline-block`). 
- Altera os arquivos de interface `game.html` e `gameEN.html` para trocar as posições das setas `UP`/`DOWN` nos controles touch. 

### Testing
- Executed `git diff --check` to validate diffs and it passed without issues. 
- Served the site with `python -m http.server 8000` and used Playwright to capture desktop and mobile screenshots, which completed successfully and produced artifacts. 
- Verified working changes locally by loading `http://127.0.0.1:8000/game.html` in the automated browser checks and there were no errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a365bea7bc8326aeda6a94c0dc2be6)