### PR TITLE
Corrige swipe mobile, travessia de borda e escala quadrada do canvas

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -33,6 +33,9 @@ restartBtn.addEventListener('click', restartGame);
 canvas.addEventListener('pointerdown', startOnTap);
 document.addEventListener('pointerdown', handleSwipeStart, { passive: true });
 document.addEventListener('pointerup', handleSwipeEnd, { passive: true });
+canvas.addEventListener('touchstart', handleTouchStart, { passive: true });
+canvas.addEventListener('touchend', handleTouchEnd, { passive: true });
+window.addEventListener('resize', applyCanvasSettings);
 controlButtons.forEach((button) => {
     button.addEventListener('pointerdown', (event) => {
         event.preventDefault();
@@ -50,6 +53,8 @@ function randomFoodPosition() {
 
 function applyCanvasSettings() {
     const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
+    const widthLimit = mobileOrTablet ? window.innerWidth * 0.92 : Math.min(window.innerWidth * 0.88, 860);
+    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.62;
 
     if (mobileOrTablet) {
         columns = 18;
@@ -61,6 +66,10 @@ function applyCanvasSettings() {
 
     canvas.width = columns * box;
     canvas.height = rows * box;
+
+    const cellInPixels = Math.floor(Math.min(widthLimit / columns, heightLimit / rows));
+    canvas.style.width = `${cellInPixels * columns}px`;
+    canvas.style.height = `${cellInPixels * rows}px`;
 }
 
 function isMobileOrTabletTouch(event) {
@@ -96,6 +105,51 @@ function handleSwipeEnd(event) {
 
     startOnTap();
     pointerStart = null;
+}
+
+function handleTouchStart(event) {
+    const touch = event.changedTouches[0];
+    if (!touch) {
+        return;
+    }
+
+    pointerStart = { x: touch.clientX, y: touch.clientY };
+}
+
+function handleTouchEnd(event) {
+    const touch = event.changedTouches[0];
+    if (!pointerStart || !touch) {
+        return;
+    }
+
+    const deltaX = touch.clientX - pointerStart.x;
+    const deltaY = touch.clientY - pointerStart.y;
+
+    if (Math.abs(deltaX) >= swipeThreshold || Math.abs(deltaY) >= swipeThreshold) {
+        if (Math.abs(deltaX) > Math.abs(deltaY)) {
+            applyDirection(deltaX > 0 ? 'RIGHT' : 'LEFT');
+        } else {
+            applyDirection(deltaY > 0 ? 'DOWN' : 'UP');
+        }
+
+        startOnTap();
+    }
+
+    pointerStart = null;
+}
+
+function normalizeHeadPosition(nextX, nextY) {
+    let snakeX = nextX;
+    let snakeY = nextY;
+
+    if (canCrossWalls) {
+        if (snakeX < 0) snakeX = columns * box - box;
+        if (snakeY < 0) snakeY = rows * box - box;
+        if (snakeX >= columns * box) snakeX = 0;
+        if (snakeY >= rows * box) snakeY = 0;
+    }
+
+    return { x: snakeX, y: snakeY };
 }
 
 function startOnTap() {
@@ -219,6 +273,10 @@ function draw(currentTime) {
         if (direction === 'RIGHT') snakeX += box;
         if (direction === 'DOWN') snakeY += box;
 
+        const normalizedHead = normalizeHeadPosition(snakeX, snakeY);
+        snakeX = normalizedHead.x;
+        snakeY = normalizedHead.y;
+
         if (snakeX === food.x && snakeY === food.y) {
             score++;
             food = randomFoodPosition();
@@ -227,13 +285,6 @@ function draw(currentTime) {
             }
         } else {
             snake.pop();
-        }
-
-        if (canCrossWalls) {
-            if (snakeX < 0) snakeX = columns * box - box;
-            if (snakeY < 0) snakeY = rows * box - box;
-            if (snakeX >= columns * box) snakeX = 0;
-            if (snakeY >= rows * box) snakeY = 0;
         }
 
         const newHead = { x: snakeX, y: snakeY };

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -2,6 +2,11 @@ const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 
 const box = 24;
+const swipeThreshold = 24;
+
+let columns = 23;
+let rows = 40;
+let pointerStart = null;
 
 let snake = [{ x: box * 5, y: box * 5 }];
 let direction = 'RIGHT';
@@ -21,9 +26,16 @@ const messageDisplay = document.getElementById('messageDisplay');
 const restartBtn = document.getElementById('restartBtn');
 const controlButtons = document.querySelectorAll('.control-btn');
 
+applyCanvasSettings();
+
 document.addEventListener('keydown', changeDirection);
 restartBtn.addEventListener('click', restartGame);
 canvas.addEventListener('pointerdown', startOnTap);
+document.addEventListener('pointerdown', handleSwipeStart, { passive: true });
+document.addEventListener('pointerup', handleSwipeEnd, { passive: true });
+canvas.addEventListener('touchstart', handleTouchStart, { passive: true });
+canvas.addEventListener('touchend', handleTouchEnd, { passive: true });
+window.addEventListener('resize', applyCanvasSettings);
 controlButtons.forEach((button) => {
     button.addEventListener('pointerdown', (event) => {
         event.preventDefault();
@@ -34,9 +46,110 @@ controlButtons.forEach((button) => {
 
 function randomFoodPosition() {
     return {
-        x: Math.floor(Math.random() * (canvas.width / box)) * box,
-        y: Math.floor(Math.random() * (canvas.height / box)) * box
+        x: Math.floor(Math.random() * columns) * box,
+        y: Math.floor(Math.random() * rows) * box
     };
+}
+
+function applyCanvasSettings() {
+    const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
+    const widthLimit = mobileOrTablet ? window.innerWidth * 0.92 : Math.min(window.innerWidth * 0.88, 860);
+    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.62;
+
+    if (mobileOrTablet) {
+        columns = 18;
+        rows = 32;
+    } else {
+        columns = 23;
+        rows = 40;
+    }
+
+    canvas.width = columns * box;
+    canvas.height = rows * box;
+
+    const cellInPixels = Math.floor(Math.min(widthLimit / columns, heightLimit / rows));
+    canvas.style.width = `${cellInPixels * columns}px`;
+    canvas.style.height = `${cellInPixels * rows}px`;
+}
+
+function isMobileOrTabletTouch(event) {
+    return window.matchMedia('(max-width: 1024px)').matches && event.pointerType === 'touch';
+}
+
+function handleSwipeStart(event) {
+    if (!isMobileOrTabletTouch(event)) {
+        return;
+    }
+
+    pointerStart = { x: event.clientX, y: event.clientY };
+}
+
+function handleSwipeEnd(event) {
+    if (!pointerStart || !isMobileOrTabletTouch(event)) {
+        return;
+    }
+
+    const deltaX = event.clientX - pointerStart.x;
+    const deltaY = event.clientY - pointerStart.y;
+
+    if (Math.abs(deltaX) < swipeThreshold && Math.abs(deltaY) < swipeThreshold) {
+        pointerStart = null;
+        return;
+    }
+
+    if (Math.abs(deltaX) > Math.abs(deltaY)) {
+        applyDirection(deltaX > 0 ? 'RIGHT' : 'LEFT');
+    } else {
+        applyDirection(deltaY > 0 ? 'DOWN' : 'UP');
+    }
+
+    startOnTap();
+    pointerStart = null;
+}
+
+function handleTouchStart(event) {
+    const touch = event.changedTouches[0];
+    if (!touch) {
+        return;
+    }
+
+    pointerStart = { x: touch.clientX, y: touch.clientY };
+}
+
+function handleTouchEnd(event) {
+    const touch = event.changedTouches[0];
+    if (!pointerStart || !touch) {
+        return;
+    }
+
+    const deltaX = touch.clientX - pointerStart.x;
+    const deltaY = touch.clientY - pointerStart.y;
+
+    if (Math.abs(deltaX) >= swipeThreshold || Math.abs(deltaY) >= swipeThreshold) {
+        if (Math.abs(deltaX) > Math.abs(deltaY)) {
+            applyDirection(deltaX > 0 ? 'RIGHT' : 'LEFT');
+        } else {
+            applyDirection(deltaY > 0 ? 'DOWN' : 'UP');
+        }
+
+        startOnTap();
+    }
+
+    pointerStart = null;
+}
+
+function normalizeHeadPosition(nextX, nextY) {
+    let snakeX = nextX;
+    let snakeY = nextY;
+
+    if (canCrossWalls) {
+        if (snakeX < 0) snakeX = columns * box - box;
+        if (snakeY < 0) snakeY = rows * box - box;
+        if (snakeX >= columns * box) snakeX = 0;
+        if (snakeY >= rows * box) snakeY = 0;
+    }
+
+    return { x: snakeX, y: snakeY };
 }
 
 function startOnTap() {
@@ -158,6 +271,10 @@ function draw(currentTime) {
         if (direction === 'RIGHT') snakeX += box;
         if (direction === 'DOWN') snakeY += box;
 
+        const normalizedHead = normalizeHeadPosition(snakeX, snakeY);
+        snakeX = normalizedHead.x;
+        snakeY = normalizedHead.y;
+
         if (snakeX === food.x && snakeY === food.y) {
             score++;
             food = randomFoodPosition();
@@ -168,16 +285,9 @@ function draw(currentTime) {
             snake.pop();
         }
 
-        if (canCrossWalls) {
-            if (snakeX < 0) snakeX = canvas.width - box;
-            if (snakeY < 0) snakeY = canvas.height - box;
-            if (snakeX >= canvas.width) snakeX = 0;
-            if (snakeY >= canvas.height) snakeY = 0;
-        }
-
         const newHead = { x: snakeX, y: snakeY };
 
-        if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= canvas.width || snakeY >= canvas.height || collision(newHead, snake))) {
+        if (!canCrossWalls && (snakeX < 0 || snakeY < 0 || snakeX >= columns * box || snakeY >= rows * box || collision(newHead, snake))) {
             endGame();
             return;
         }

--- a/gameEN.html
+++ b/gameEN.html
@@ -19,6 +19,8 @@
             <img src="./images/einstein-logo.png" alt="Einstein Logo" height="50">
         </div>
 
+        <div id="messageDisplay">Tap the game to start and help Einstein capture the photons! 💡</div>
+
         <div class="container">
             <div class="info">
                 <div id="scoreBox">Photons: 0</div>
@@ -38,8 +40,6 @@
                 </div>
             </div>
         </div>
-
-        <div id="messageDisplay">Tap the game to start and help Einstein capture the photons! 💡</div>
     </main>
 
     <footer>Created by Lucas Ferreira (UnB/MNPEF) - CC BY-NC-ND 4.0</footer>

--- a/styles.css
+++ b/styles.css
@@ -47,13 +47,11 @@ body {
 
 #gameCanvas {
     width: min(88vw, 860px);
-    max-height: 62vh;
-    aspect-ratio: 23 / 40;
     border: 1px solid #f0f0f0;
     background-color: #111;
     opacity: 0.95;
     border-radius: 5px;
-    touch-action: manipulation;
+    touch-action: none;
 }
 
 .info {
@@ -208,8 +206,6 @@ h1 {
 
     #gameCanvas {
         width: min(92vw, 432px);
-        max-height: 60vh;
-        aspect-ratio: 9 / 16;
     }
 
     .info,
@@ -234,7 +230,7 @@ h1 {
     }
 
     #messageDisplay {
-        margin-top: -20px;
+        margin-top: 0;
         margin-bottom: 10px;
     }
 


### PR DESCRIPTION
### Motivation
- Corrigir o controle por swipe no mobile/tablet porque o gesto não estava sendo detectado corretamente no canvas. 
- Impedir que, ao entrar no modo de atravessar paredes (cobra azul), a captura de blocos amarelos na borda seja perdida. 
- Garantir que as células (cobra e fótons) renderizem realmente quadradas em desktop e mobile/tablet e mover o `messageDisplay` na versão EN conforme solicitado.

### Description
- Adiciona `touchstart`/`touchend` como fallback além dos eventos pointer e registra `resize` para recalcular o canvas, implementado em `functions.js` e `functionsEN.js` para paridade entre idiomas. 
- Normaliza a posição da cabeça com `normalizeHeadPosition` antes das checagens de colisão/captura para que a captura de alimentos na borda não seja perdida ao ativar `canCrossWalls`. 
- Muda o dimensionamento do canvas para usar um único fator por célula (calcula `cellInPixels` a partir de limites de largura/altura) e aplica `canvas.style.width/height` para preservar células quadradas; também ajusta `touch-action` e remove restrições conflitantes de `aspect-ratio`/`max-height` em `styles.css`. 
- Move o elemento `#messageDisplay` na versão inglesa (`gameEN.html`) para ficar entre o título e o canvas, alinhando a posição solicitada para mobile/tablet.

### Testing
- Executado `node --check functions.js` com sucesso. 
- Executado `node --check functionsEN.js` com sucesso. 
- Iniciado `python -m http.server` para testes manuais no navegador local com sucesso, porém a tentativa automatizada de capturar screenshots via Playwright falhou devido a um crash do Chromium (SIGSEGV) neste ambiente de execução. 
- Verificadas mudanças de arquivos principais: `functions.js`, `functionsEN.js`, `styles.css`, e `gameEN.html`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a37241dda4832699bfeef0b8b5f449)