### PR TITLE
Adjust game and language layouts across desktop and mobile

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -53,8 +53,6 @@ function randomFoodPosition() {
 
 function applyCanvasSettings() {
     const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
-    const widthLimit = mobileOrTablet ? window.innerWidth * 0.92 : Math.min(window.innerWidth * 0.88, 860);
-    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.62;
 
     if (mobileOrTablet) {
         columns = 18;
@@ -63,6 +61,9 @@ function applyCanvasSettings() {
         columns = 23;
         rows = 40;
     }
+
+    const widthLimit = Math.max(window.innerWidth - 20, columns * box);
+    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.86;
 
     canvas.width = columns * box;
     canvas.height = rows * box;

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -53,8 +53,6 @@ function randomFoodPosition() {
 
 function applyCanvasSettings() {
     const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
-    const widthLimit = mobileOrTablet ? window.innerWidth * 0.92 : Math.min(window.innerWidth * 0.88, 860);
-    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.62;
 
     if (mobileOrTablet) {
         columns = 18;
@@ -63,6 +61,9 @@ function applyCanvasSettings() {
         columns = 23;
         rows = 40;
     }
+
+    const widthLimit = Math.max(window.innerWidth - 20, columns * box);
+    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.86;
 
     canvas.width = columns * box;
     canvas.height = rows * box;

--- a/game.html
+++ b/game.html
@@ -15,8 +15,10 @@
 <body>
     <main class="game-page">
         <div class="title">
-            <h1>Einstein Snake</h1>
-            <img src="./images/einstein-logo.png" alt="Logo Einstein" height="50">
+            <div class="title-row">
+                <h1>Einstein Snake</h1>
+                <img src="./images/einstein-logo.png" alt="Logo Einstein" height="50">
+            </div>
             <div id="messageDisplay">Toque no jogo para iniciar e ajudar o Einstein a capturar os fótons! 💡</div>
         </div>
 

--- a/gameEN.html
+++ b/gameEN.html
@@ -15,8 +15,10 @@
 <body>
     <main class="game-page">
         <div class="title">
-            <h1>Einstein Snake</h1>
-            <img src="./images/einstein-logo.png" alt="Einstein Logo" height="50">
+            <div class="title-row">
+                <h1>Einstein Snake</h1>
+                <img src="./images/einstein-logo.png" alt="Einstein Logo" height="50">
+            </div>
         </div>
 
         <div id="messageDisplay">Tap the game to start and help Einstein capture the photons! 💡</div>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,8 @@
 </head>
 <body>
     <div class="language-container">
-        <h1>Escolha o Idioma | Choose the Language</h1>
+        <h1 class="language-title">Escolha o Idioma</h1>
+        <h2 class="language-subtitle">Choose the Language</h2>
         <div class="buttons">
             <a href="game.html" class="lang-btn-pt" id="btnPT">Português</a>
             <a href="gameEN.html" class="lang-btn-en" id="btnEN">English</a>

--- a/styles.css
+++ b/styles.css
@@ -18,7 +18,7 @@ body {
 }
 
 .game-page {
-    max-width: 1200px;
+    max-width: 100%;
     margin: 0 auto;
     height: calc(100vh - 24px);
     display: flex;
@@ -38,6 +38,13 @@ body {
     margin: 8px 0 12px;
 }
 
+.title-row {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+}
+
 .container {
     display: flex;
     flex-direction: column;
@@ -46,7 +53,7 @@ body {
 }
 
 #gameCanvas {
-    width: min(88vw, 860px);
+    width: calc(100vw - 20px);
     border: 1px solid #f0f0f0;
     background-color: #111;
     opacity: 0.95;
@@ -55,7 +62,7 @@ body {
 }
 
 .info {
-    width: min(88vw, 860px);
+    width: calc(100vw - 20px);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -118,7 +125,7 @@ body {
 }
 
 #messageDisplay {
-    width: min(88vw, 860px);
+    width: calc(100vw - 20px);
     font-size: clamp(18px, 2.3vw, 24px);
     text-align: center;
     display: flex;
@@ -158,6 +165,17 @@ h1 {
     font-size: clamp(26px, 4vw, 36px);
     margin: 0;
     color: #f0f0f0;
+}
+
+.language-title,
+.language-subtitle {
+    text-align: center;
+}
+
+.language-subtitle {
+    font-size: clamp(24px, 3.2vw, 32px);
+    font-family: "Orbitron", sans-serif;
+    margin: 0 0 20px;
 }
 
 .buttons {
@@ -204,14 +222,10 @@ h1 {
         display: flex;
     }
 
-    #gameCanvas {
-        width: min(92vw, 432px);
-    }
-
     .info,
     .touch-controls,
     #messageDisplay {
-        width: min(92vw, 540px);
+        width: calc(100vw - 20px);
     }
 
     .touch-controls {
@@ -236,5 +250,17 @@ h1 {
 
     .info {
         margin-bottom: 0;
+    }
+
+    .buttons {
+        flex-direction: column;
+        align-items: center;
+        gap: 20px;
+    }
+
+    .language-title,
+    .language-subtitle {
+        margin-left: auto;
+        margin-right: auto;
     }
 }


### PR DESCRIPTION
### Motivation
- Improve layout so the Einstein logo sits on the same line as the game title and the language selection text is visually clearer on small screens.
- Make the canvas, message and info regions span the viewport with 10px side margins so the Photons label and Restart button align with the canvas on desktop.
- Increase the visual size of grid squares on desktop while preserving the simulation grid cell proportions.

### Description
- Put the title and logo into a new `.title-row` wrapper in `game.html` and `gameEN.html` to keep them on a single horizontal line.
- Make the top-level game container use full width by setting `.game-page { max-width: 100%; }` and set `#gameCanvas`, `.info`, and `#messageDisplay` to `width: calc(100vw - 20px)` in `styles.css` to provide 10px side margins.
- Adjust `applyCanvasSettings()` in `functions.js` and `functionsEN.js` to compute `columns`/`rows` first and then use `widthLimit = Math.max(window.innerWidth - 20, columns * box)` and a larger desktop `heightLimit` so square cells render larger without changing `columns`/`rows` or simulation logic.
- Replace the combined language heading with two elements in `index.html` (`.language-title` and `.language-subtitle`) and add styles to center them and add `margin-bottom: 20px` on the subtitle for mobile/tablet, plus stack language buttons vertically on small screens.

### Testing
- Ran `node --check functions.js` and `node --check functionsEN.js`, both checks passed.
- Served the app locally with `python3 -m http.server 8000` and captured visual validation screenshots (desktop game layout and mobile language layout) using a Playwright script, which completed successfully.
- Performed a quick layout verification in desktop and mobile viewport screenshots and confirmed the title/logo alignment, canvas/info/message width alignment, and stacked language headings on smaller screens.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a377826b688326a7364fac6b1e145a)