### PR TITLE
Responsive canvas scaling (96vw/65vh mobile, 70vw/50vh desktop) and unified language fonts

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -53,6 +53,8 @@ function randomFoodPosition() {
 
 function applyCanvasSettings() {
     const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
+    const targetWidthRatio = mobileOrTablet ? 0.96 : 0.70;
+    const targetHeightRatio = mobileOrTablet ? 0.65 : 0.50;
 
     if (mobileOrTablet) {
         columns = 18;
@@ -62,15 +64,18 @@ function applyCanvasSettings() {
         rows = 40;
     }
 
-    const widthLimit = Math.max(window.innerWidth - 20, columns * box);
-    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.86;
+    const widthLimit = window.innerWidth * targetWidthRatio;
+    const heightLimit = window.innerHeight * targetHeightRatio;
 
     canvas.width = columns * box;
     canvas.height = rows * box;
 
-    const cellInPixels = Math.floor(Math.min(widthLimit / columns, heightLimit / rows));
-    canvas.style.width = `${cellInPixels * columns}px`;
-    canvas.style.height = `${cellInPixels * rows}px`;
+    const gridWidth = columns * box;
+    const gridHeight = rows * box;
+    const scale = Math.min(widthLimit / gridWidth, heightLimit / gridHeight);
+
+    canvas.style.width = `${gridWidth * scale}px`;
+    canvas.style.height = `${gridHeight * scale}px`;
 }
 
 function isMobileOrTabletTouch(event) {

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -53,6 +53,8 @@ function randomFoodPosition() {
 
 function applyCanvasSettings() {
     const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
+    const targetWidthRatio = mobileOrTablet ? 0.96 : 0.70;
+    const targetHeightRatio = mobileOrTablet ? 0.65 : 0.50;
 
     if (mobileOrTablet) {
         columns = 18;
@@ -62,15 +64,18 @@ function applyCanvasSettings() {
         rows = 40;
     }
 
-    const widthLimit = Math.max(window.innerWidth - 20, columns * box);
-    const heightLimit = mobileOrTablet ? window.innerHeight * 0.6 : window.innerHeight * 0.86;
+    const widthLimit = window.innerWidth * targetWidthRatio;
+    const heightLimit = window.innerHeight * targetHeightRatio;
 
     canvas.width = columns * box;
     canvas.height = rows * box;
 
-    const cellInPixels = Math.floor(Math.min(widthLimit / columns, heightLimit / rows));
-    canvas.style.width = `${cellInPixels * columns}px`;
-    canvas.style.height = `${cellInPixels * rows}px`;
+    const gridWidth = columns * box;
+    const gridHeight = rows * box;
+    const scale = Math.min(widthLimit / gridWidth, heightLimit / gridHeight);
+
+    canvas.style.width = `${gridWidth * scale}px`;
+    canvas.style.height = `${gridHeight * scale}px`;
 }
 
 function isMobileOrTabletTouch(event) {

--- a/styles.css
+++ b/styles.css
@@ -170,6 +170,7 @@ h1 {
 .language-title,
 .language-subtitle {
     text-align: center;
+    font-family: "Orbitron", sans-serif;
 }
 
 .language-subtitle {
@@ -192,6 +193,7 @@ h1 {
     font-size: 30px;
     background-color: #000000;
     color: #ffffff;
+    font-family: "Orbitron", sans-serif;
     text-decoration: none;
     border-radius: 5px;
     overflow: hidden;
@@ -204,6 +206,7 @@ h1 {
     font-size: 30px;
     background-color: #000000;
     color: #ffffff;
+    font-family: "Orbitron", sans-serif;
     text-decoration: none;
     border-radius: 5px;
     overflow: hidden;


### PR DESCRIPTION
### Motivation
- Garantir que o canvas siga proporções fixas da viewport por dispositivo para manter os quadrados (cobra/comida) sempre quadrados. 
- Aplicar o mesmo comportamento responsivo nas versões PT e EN do jogo. 
- Padronizar a tipografia na tela de escolha de idioma para que ambos os textos e botões usem a mesma fonte.

### Description
- Atualizei a lógica de redimensionamento do canvas em `functions.js` para usar `96vw x 65vh` em mobile/tablet e `70vw x 50vh` em desktop, calculando um único fator de escala para preservar a proporção do grid e manter células quadradas. 
- Apliquei a mesma alteração em `functionsEN.js` para manter comportamento idêntico na versão em inglês. 
- Padronizei fonte `Orbitron` para `.language-title`, `.language-subtitle` e os botões `.lang-btn-pt` / `.lang-btn-en` em `styles.css`. 
- Mantive intacta a lógica de jogo e a grade de colisão; apenas a exibição/escala do canvas e a tipografia da tela inicial foram alteradas.

### Testing
- Executei um servidor local com `python3 -m http.server 4173 --bind 0.0.0.0` para validação visual e o servidor respondeu com sucesso. 
- Capturei screenshots usando Playwright em viewports desktop e mobile e também da `index.html` para verificar tipografia; as capturas foram geradas em `artifacts/` com sucesso. 
- Verifiquei as diffs e confirmei as mudanças em `functions.js`, `functionsEN.js` e `styles.css` com `git diff` e efetuei `git commit` sem erros. 
- Todos os testes automatizados/visuais executados (servidor + Playwright screenshots + commit) finalizaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a37e14c738832699fd05d5b6e2a3ca)