### PR TITLE
Adapt canvas sizing to desktop/tablet/mobile profiles and preserve square cells

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -52,13 +52,17 @@ function randomFoodPosition() {
 }
 
 function applyCanvasSettings() {
-    const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
-    const targetWidthRatio = mobileOrTablet ? 0.96 : 0.70;
-    const targetHeightRatio = mobileOrTablet ? 0.65 : 0.50;
+    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+    const isTablet = window.matchMedia('(min-width: 769px) and (max-width: 1024px)').matches;
+    const targetWidthRatio = isMobile ? 0.96 : 0.70;
+    const targetHeightRatio = 0.60;
 
-    if (mobileOrTablet) {
+    if (isMobile) {
         columns = 18;
         rows = 32;
+    } else if (isTablet) {
+        columns = 21;
+        rows = 36;
     } else {
         columns = 23;
         rows = 40;

--- a/functionsEN.js
+++ b/functionsEN.js
@@ -52,13 +52,17 @@ function randomFoodPosition() {
 }
 
 function applyCanvasSettings() {
-    const mobileOrTablet = window.matchMedia('(max-width: 1024px)').matches;
-    const targetWidthRatio = mobileOrTablet ? 0.96 : 0.70;
-    const targetHeightRatio = mobileOrTablet ? 0.65 : 0.50;
+    const isMobile = window.matchMedia('(max-width: 768px)').matches;
+    const isTablet = window.matchMedia('(min-width: 769px) and (max-width: 1024px)').matches;
+    const targetWidthRatio = isMobile ? 0.96 : 0.70;
+    const targetHeightRatio = 0.60;
 
-    if (mobileOrTablet) {
+    if (isMobile) {
         columns = 18;
         rows = 32;
+    } else if (isTablet) {
+        columns = 21;
+        rows = 36;
     } else {
         columns = 23;
         rows = 40;


### PR DESCRIPTION
### Motivation
- Tornar o canvas responsivo usando perfis de tela explícitos (desktop, tablet e mobile) para respeitar as dimensões desejadas de layout e permitir adaptação a qualquer dispositivo.
- Garantir que os blocos do jogo (cobra e comida) permaneçam quadrados ao redimensionar o canvas para diferentes viewports.

### Description
- Atualizei a função `applyCanvasSettings()` em `functions.js` para detectar `isMobile` e `isTablet` e aplicar perfis distintos de colunas/linhas (`columns`/`rows`).
- Passei a usar proporções alvo de largura/altura: mobile `96vw` x `60vh` (via `targetWidthRatio = 0.96`, `targetHeightRatio = 0.60`) e tablet/desktop `70vw` x `60vh` (via `targetWidthRatio = 0.70`, `targetHeightRatio = 0.60`).
- Preservei a forma quadrada dos blocos calculando um `scale` uniforme com `Math.min(widthLimit / gridWidth, heightLimit / gridHeight)` e aplicando-o a `canvas.style.width`/`height`.
- Espelhei a mesma alteração em `functionsEN.js` para manter comportamento consistente entre as versões PT/EN.

### Testing
- `node --check functions.js` — passou com sucesso.
- `node --check functionsEN.js` — passou com sucesso.
- Executado servidor local com `python3 -m http.server 4173` e verificação visual automatizada via Playwright que gerou screenshots para desktop e mobile, ambas com renderização correta do canvas e blocos quadrados (sucesso).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a383b8ffd88326af01e31d7692f0ea)